### PR TITLE
fix windows build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,12 @@ parking_lot = "0.12.1"
 reqwest = { version = "0.11.11", default-features = false, features = ["json"] }
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
-simple-signal = "1.1.1"
 tokio = { version = "1.19.2", features = ["macros", "io-std"] }
 toml = "0.7.2"
 version = "3.0.0"
+
+[target.'cfg(unix)'.dependencies]
+simple-signal = "1.1.1"
 
 [dev-dependencies]
 assert-panic = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,10 +28,12 @@ use lib::{
 use log::{error, warn, LevelFilter};
 use parking_lot::RwLock;
 use serde_json::Value;
+#[cfg(unix)]
 use simple_signal::Signal;
 use std::collections::HashMap;
 use tokio::io::AsyncReadExt;
 
+#[cfg(unix)]
 use crate::consts::EXIT_CODE_INTERRUPTED;
 
 static ABORT_ON_INTERRUPT: RwLock<bool> = RwLock::new(true);
@@ -203,6 +205,7 @@ async fn main() {
     log::set_max_level(LevelFilter::max());
     log::set_logger(&*LOGGER).expect("this can only fail if a logger has already been set");
 
+    #[cfg(unix)]
     simple_signal::set_handler(&[Signal::Int], |signals| {
         if *ABORT_ON_INTERRUPT.read() {
             error!("received signals: {signals:?} - aborting");


### PR DESCRIPTION
Disable `simple-signal` hooks for non-unix-like platforms