### PR TITLE
fix config tests after file locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "test_helpers",
  "tokio",
  "toml",
+ "uuid",
  "version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ assert-panic = "1.0.1"
 httptest = "0.15.4"
 mockall = "0.11.3"
 test_helpers = { path = "test_helpers" }
+uuid = "1.3.0"
 
 [features]
 default = ["rustls-native-certs"]


### PR DESCRIPTION
This also ensures that a default config is written if `pexshell` exits with an unrelated error on first run, rather than leaving behind an empty config file.