### PR TITLE
Respect the allowed HTTP methods on endpoints

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -573,7 +573,6 @@ mod tests {
         );
         assert_eq!(
             command
-                .clone()
                 .try_get_matches_from(["test", "status", "conference", "patch", "1"])
                 .unwrap_err()
                 .kind(),


### PR DESCRIPTION
Before this change any type of request could be sent to any endpoint, many of which just result in a 405 Method Not Allowed. For example, sending a DELETE request to the `status` API is never allowed.

This change uses the `allowed_detail_http_methods` member of the `Endpoint` to decide which subcommands to add.