### PR TITLE
CI: disable triggering CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,6 @@ name: CI
 on:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - master
-    tags:
-      - "*"
 
 jobs:
   build:


### PR DESCRIPTION
We shouldn't need to run CI on a push anymore, as commits to master go through a merge queue.