### PR TITLE
CI: re-enable CI on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Currently, workflows that run under the `Merge Queue` push their cache with the temporary branch name. This means that the caching does not work, as the cache is not pushed under the base branch name.

Relevant Github discussion: https://github.com/orgs/community/discussions/47349 
Comment on public feedback for `Merge Queue`: https://github.com/orgs/community/discussions/46757#discussioncomment-4970080
