### PR TITLE
clippy: allow clippy::significant_drop_in_scrutinee lint

### DIFF
--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::redundant_pub_crate)]
 #![allow(clippy::missing_panics_doc)]
+#![allow(clippy::significant_drop_in_scrutinee)]
 
 pub mod fs;
 pub mod future;


### PR DESCRIPTION
This is a nursery lint with a lot of false-positives, since it's a frequent pattern to match on the contents of a mutex.