### PR TITLE
redirect stderr in tests, just like stdout

### DIFF
--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -233,7 +233,7 @@ impl<Backend: Interact> Login<Backend> {
         for user in config.get_users() {
             let mut user_ident = combine_username(user, local_timezone());
             if user.current_user {
-                if console.is_interactive() {
+                if console.is_stdout_interactive() {
                     user_ident = console::Style::new()
                         .fg(console::Color::Green)
                         .apply_to(user_ident)
@@ -370,7 +370,7 @@ mod tests {
 
         let backend = MockInteract::new();
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out.clone(), VirtualFile::new());
+        let mut console = Console::new(false, out.clone(), false, VirtualFile::new());
 
         let mut login = Login::new(backend);
 
@@ -446,7 +446,7 @@ mod tests {
             .return_const(());
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out, VirtualFile::new());
+        let mut console = Console::new(false, out, false, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact
@@ -515,7 +515,7 @@ mod tests {
             .return_const(());
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out, VirtualFile::new());
+        let mut console = Console::new(false, out, false, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact
@@ -619,7 +619,7 @@ mod tests {
         }
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out, VirtualFile::new());
+        let mut console = Console::new(false, out, false, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -370,7 +370,7 @@ mod tests {
 
         let backend = MockInteract::new();
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out.clone());
+        let mut console = Console::new(false, out.clone(), VirtualFile::new());
 
         let mut login = Login::new(backend);
 
@@ -446,7 +446,7 @@ mod tests {
             .return_const(());
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out);
+        let mut console = Console::new(false, out, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact
@@ -515,7 +515,7 @@ mod tests {
             .return_const(());
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out);
+        let mut console = Console::new(false, out, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact
@@ -619,7 +619,7 @@ mod tests {
         }
 
         let out = VirtualFile::new();
-        let mut console = Console::new(false, out);
+        let mut console = Console::new(false, out, VirtualFile::new());
         let mut login = Login::new(backend);
         login
             .interact

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -43,7 +43,7 @@ impl Console {
             static ref STYLE: console::Style = console::Style::new().fg(console::Color::Yellow);
         }
         writeln!(
-            self.stdout,
+            self.stderr,
             "{}",
             STYLE.apply_to(format!("Warning: {message}"))
         )

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,26 +15,33 @@ use log::{debug, warn};
 use serde_json::{json, Map, Value};
 
 pub struct Console {
-    is_interactive: bool,
+    is_stdout_interactive: bool,
+    is_stderr_interactive: bool,
     stdout: Box<dyn Write + Send>,
     stderr: Box<dyn Write + Send>,
 }
 
 impl Console {
     pub fn new<Out: Write + Send + 'static, Error: Write + Send + 'static>(
-        is_interactive: bool,
+        is_stdout_interactive: bool,
         stdout: Out,
+        is_stderr_interactive: bool,
         stderr: Error,
     ) -> Self {
         Self {
-            is_interactive,
+            is_stdout_interactive,
             stdout: Box::new(stdout),
+            is_stderr_interactive,
             stderr: Box::new(stderr),
         }
     }
 
-    pub const fn is_interactive(&self) -> bool {
-        self.is_interactive
+    pub const fn is_stdout_interactive(&self) -> bool {
+        self.is_stdout_interactive
+    }
+
+    pub const fn is_stderr_interactive(&self) -> bool {
+        self.is_stderr_interactive
     }
 
     pub fn display_warning(&mut self, message: &str) {
@@ -51,7 +58,7 @@ impl Console {
     }
 
     pub fn pretty_print_json(&mut self, json: &Value) {
-        let pretty = if self.is_interactive() {
+        let pretty = if self.is_stdout_interactive() {
             debug!("Stdout is a terminal - pretty-printing json in colour");
             to_coloured_json_auto(json).unwrap()
         } else {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,13 +17,19 @@ use serde_json::{json, Map, Value};
 pub struct Console {
     is_interactive: bool,
     stdout: Box<dyn Write + Send>,
+    stderr: Box<dyn Write + Send>,
 }
 
 impl Console {
-    pub fn new<Out: Write + Send + 'static>(is_interactive: bool, stdout: Out) -> Self {
+    pub fn new<Out: Write + Send + 'static, Error: Write + Send + 'static>(
+        is_interactive: bool,
+        stdout: Out,
+        stderr: Error,
+    ) -> Self {
         Self {
             is_interactive,
             stdout: Box::new(stdout),
+            stderr: Box::new(stderr),
         }
     }
 
@@ -53,6 +59,10 @@ impl Console {
             serde_json::to_string_pretty(json).unwrap()
         };
         writeln!(&mut self.stdout, "{pretty}").unwrap();
+    }
+
+    pub fn stderr(&mut self) -> &mut (dyn Write + Send) {
+        &mut self.stderr
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -573,7 +573,11 @@ mod tests {
         let config = "";
         let config_path = work_dir.join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         std::fs::write(&config_path, config).unwrap();
 
         // Act
@@ -600,7 +604,11 @@ mod tests {
         let config = b"\xf0\x28\x8c\x28";
         let config_path = work_dir.join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         std::fs::write(&config_path, config).unwrap();
 
         // Act
@@ -643,7 +651,11 @@ mod tests {
         "#;
         let config_path = work_dir.join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         std::fs::write(&config_path, config).unwrap();
 
         // Act
@@ -721,7 +733,11 @@ mod tests {
         let config_path = test_context.get_test_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
         let keyring = credentials::MockProvider::new();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -771,7 +787,11 @@ last_used = 1192778584
         let config_path = test_context.get_test_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
         let keyring = credentials::MockProvider::new();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -810,7 +830,11 @@ last_used = 1192778584
         let config_path = test_context.get_test_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
         let keyring = credentials::MockProvider::new();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -862,7 +886,11 @@ last_used = 1192778584
         let config_path = test_context.get_test_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
         let keyring = credentials::MockProvider::new();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -927,7 +955,11 @@ current_user = true
         let config_path = test_context.get_test_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
         let keyring = credentials::MockProvider::new();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -1012,7 +1044,11 @@ current_user = true
             )
             .once()
             .return_once(|_, _, _| Ok(()));
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -1094,7 +1130,11 @@ current_user = true
             )
             .once()
             .return_once(|_, _, _| Err(keyring::Error::NoEntry));
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mut mgr = Manager::with_config_and_keyring(
             config,
@@ -1142,7 +1182,11 @@ current_user = true
         let config = Config::new(&dirs);
         let config_path = test_context.get_config_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         let mgr = Manager::with_config_and_keyring(
             config,
             &config_path,
@@ -1192,7 +1236,11 @@ current_user = true
         };
         let config_path = test_context.get_config_dir().join("config.toml");
         let lock_path = test_context.get_test_dir().join("config.lock");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         let mgr = Manager::with_config_and_keyring(
             config,
             &config_path,
@@ -1235,7 +1283,11 @@ current_user = true
                 String::from("super_secret_password"),
             ),
         ]);
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mgr = Manager::with_config_and_keyring(
             config,
@@ -1294,7 +1346,11 @@ current_user = true
             .iter()
             .map(|&(k, v)| (k.to_owned(), v.to_owned()))
             .collect::<HashMap<_, _>>();
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mgr = Manager::with_config_and_keyring(
             config,
@@ -1350,7 +1406,11 @@ current_user = true
             ),
             (String::from("PEXSHELL_USERNAME"), String::from("admin")),
         ]);
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
 
         let mgr = Manager::with_config_and_keyring(
             config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -576,6 +576,7 @@ mod tests {
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         std::fs::write(&config_path, config).unwrap();
@@ -607,6 +608,7 @@ mod tests {
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         std::fs::write(&config_path, config).unwrap();
@@ -654,6 +656,7 @@ mod tests {
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         std::fs::write(&config_path, config).unwrap();
@@ -736,6 +739,7 @@ mod tests {
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -790,6 +794,7 @@ last_used = 1192778584
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -833,6 +838,7 @@ last_used = 1192778584
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -889,6 +895,7 @@ last_used = 1192778584
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -958,6 +965,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -1047,6 +1055,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -1133,6 +1142,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -1185,6 +1195,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         let mgr = Manager::with_config_and_keyring(
@@ -1239,6 +1250,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         let mgr = Manager::with_config_and_keyring(
@@ -1286,6 +1298,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -1349,6 +1362,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 
@@ -1409,6 +1423,7 @@ current_user = true
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
 

--- a/src/end_to_end_tests/cache.rs
+++ b/src/end_to_end_tests/cache.rs
@@ -95,6 +95,7 @@ fn cache_conference_config() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -129,6 +130,7 @@ fn clear_cache() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -216,6 +218,7 @@ fn schema_field_with_dict_type_does_not_cause_crash() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -230,6 +233,7 @@ fn schema_field_with_dict_type_does_not_cause_crash() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/end_to_end_tests/delete.rs
+++ b/src/end_to_end_tests/delete.rs
@@ -36,6 +36,7 @@ fn delete_conference_config() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/end_to_end_tests/get.rs
+++ b/src/end_to_end_tests/get.rs
@@ -44,6 +44,7 @@ fn get_conference_config() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/end_to_end_tests/get_all.rs
+++ b/src/end_to_end_tests/get_all.rs
@@ -51,6 +51,7 @@ fn get_returns_zero_objects() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -102,6 +103,7 @@ fn get_returns_page() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -198,6 +200,7 @@ fn get_multiple_pages() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -275,6 +278,7 @@ fn get_limited_to_first_page() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/end_to_end_tests/mod.rs
+++ b/src/end_to_end_tests/mod.rs
@@ -94,6 +94,7 @@ fn basic_get() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 }

--- a/src/end_to_end_tests/patch.rs
+++ b/src/end_to_end_tests/patch.rs
@@ -51,6 +51,7 @@ fn patch_conference_config() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/end_to_end_tests/post.rs
+++ b/src/end_to_end_tests/post.rs
@@ -54,6 +54,7 @@ fn post_conference_config() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 
@@ -96,6 +97,7 @@ fn post_conference_lock_command() {
             HashMap::default(),
             &test_context.get_directories(),
             test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
         ))
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,7 +238,7 @@ async fn main() {
 
     let stdout = std::io::stdout();
     let is_stdout_interactive = stdout.is_terminal();
-    let console = Console::new(is_stdout_interactive, stdout);
+    let console = Console::new(is_stdout_interactive, stdout, std::io::stderr());
 
     let env: HashMap<String, String> = std::env::vars().collect();
 
@@ -264,7 +264,12 @@ pub async fn run_with(
     env: HashMap<String, String>,
     dirs: &Directories,
     stdout_wrapper: impl std::io::Write + Send + 'static,
+    stderr_wrapper: impl std::io::Write + Send + 'static,
 ) -> anyhow::Result<()> {
-    let mut pexshell = pexshell::PexShell::new(dirs, Console::new(false, stdout_wrapper), env);
+    let mut pexshell = pexshell::PexShell::new(
+        dirs,
+        Console::new(false, stdout_wrapper, stderr_wrapper),
+        env,
+    );
     pexshell.run(args.to_vec()).await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,12 +233,13 @@ async fn main() {
     });
 
     let args: Vec<String> = std::env::args().collect();
-    let is_stderr_interactive = std::io::stderr().is_terminal();
     let dirs = Directories::default();
 
     let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
     let is_stdout_interactive = stdout.is_terminal();
-    let console = Console::new(is_stdout_interactive, stdout, std::io::stderr());
+    let is_stderr_interactive = stderr.is_terminal();
+    let console = Console::new(is_stdout_interactive, stdout, is_stderr_interactive, stderr);
 
     let env: HashMap<String, String> = std::env::vars().collect();
 
@@ -268,7 +269,7 @@ pub async fn run_with(
 ) -> anyhow::Result<()> {
     let mut pexshell = pexshell::PexShell::new(
         dirs,
-        Console::new(false, stdout_wrapper, stderr_wrapper),
+        Console::new(false, stdout_wrapper, false, stderr_wrapper),
         env,
     );
     pexshell.run(args.to_vec()).await

--- a/src/pexshell.rs
+++ b/src/pexshell.rs
@@ -164,7 +164,9 @@ impl<'a> PexShell<'a> {
                         "schema cache is missing - please generate it with: pexshell cache",
                     );
                 }
-                error.exit()
+
+                writeln!(self.console.stderr(), "{}", error.render())?;
+                std::process::exit(error.exit_code());
             }
         };
 
@@ -258,7 +260,11 @@ mod tests {
         let test_context = get_test_context();
         let dirs = test_context.get_directories();
         let config_path = dirs.config_dir.join("config.toml");
-        let mut console = Console::new(false, test_context.get_stdout_wrapper());
+        let mut console = Console::new(
+            false,
+            test_context.get_stdout_wrapper(),
+            test_context.get_stderr_wrapper(),
+        );
         assert!(!config_path.exists());
 
         // Act

--- a/src/pexshell.rs
+++ b/src/pexshell.rs
@@ -165,7 +165,11 @@ impl<'a> PexShell<'a> {
                     );
                 }
 
-                writeln!(self.console.stderr(), "{}", error.render())?;
+                if self.console.is_stderr_interactive() {
+                    writeln!(self.console.stderr(), "{}", error.render().ansi())?;
+                } else {
+                    writeln!(self.console.stderr(), "{}", error.render())?;
+                }
                 std::process::exit(error.exit_code());
             }
         };
@@ -263,6 +267,7 @@ mod tests {
         let mut console = Console::new(
             false,
             test_context.get_stdout_wrapper(),
+            false,
             test_context.get_stderr_wrapper(),
         );
         assert!(!config_path.exists());

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -121,6 +121,7 @@ pub struct TestContext {
     clean_up: bool,
     tokio_runtime: tokio::runtime::Runtime,
     stdout_buffer: Arc<Mutex<String>>,
+    stderr_buffer: Arc<Mutex<String>>,
     logging_permit: Mutex<Option<TestLoggerPermit<'static>>>,
     logging_context: OnceCell<TestLoggerContext<'static>>,
 }
@@ -153,6 +154,7 @@ impl TestContext {
         log::set_max_level(LevelFilter::max());
         info!("test work dir: {}", test_dir.to_str().unwrap());
         let stdout_buffer = Arc::new(Mutex::new(String::new()));
+        let stderr_buffer = Arc::new(Mutex::new(String::new()));
 
         Self {
             test_dir,
@@ -164,6 +166,7 @@ impl TestContext {
                 .build()
                 .unwrap(),
             stdout_buffer,
+            stderr_buffer,
             logging_permit: Mutex::new(Some(LOGGER.get_permit())),
             logging_context: OnceCell::new(),
         }
@@ -268,6 +271,11 @@ impl TestContext {
 
     pub fn get_stdout_wrapper(&self) -> impl std::io::Write {
         let buffer = Arc::clone(&self.stdout_buffer);
+        VirtualFile { buffer }
+    }
+
+    pub fn get_stderr_wrapper(&self) -> impl std::io::Write {
+        let buffer = Arc::clone(&self.stderr_buffer);
         VirtualFile { buffer }
     }
 


### PR DESCRIPTION
Currently, this is only so that clap-related errors can print to stderr without bypassing the test environment.