### PR TITLE
remove unnecessary logger clear in `TestContext::drop()`

### DIFF
--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -133,7 +133,6 @@ impl Drop for TestContext {
                  {:?}.",
                 &self.test_dir
             );
-            self.logger().clear();
         } else {
             self.logger().verify();
             if self.clean_up && self.test_dir.exists() {


### PR DESCRIPTION
We already call this `clear()` in the `TestLoggerContext` drop function.