### PR TITLE
move common package fields to workspace.package table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         id: msrv
         with:
           file: 'Cargo.toml'
-          field: 'package.rust-version'
+          field: 'workspace.package.rust-version'
       - uses: ./.github/actions/prepare
         with:
           cache-id: debug-build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [workspace]
 members = ["lib", "test_helpers"]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.70"
+license = "BSD-3-Clause"
+
 [workspace.dependencies]
 anyhow = "1.0"
 async-stream = "0.3.5"
@@ -33,12 +39,12 @@ uuid = { version = "1.6", features = ["v4"] }
 
 [package]
 name = "pexshell"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 autotests = false
 autobins = false
-rust-version = "1.70"
-license = "BSD-3-Clause"
 
 [[bin]]
 name = "pexshell"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pex_lib"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.70"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [lib]
 name = "pexlib"

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "test_helpers"
-version = "0.1.0"
-edition = "2021"
-rust-version = "1.70"
-license = "BSD-3-Clause"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
This means we don't need to update all three `Cargo.toml` files every time we change something like the msrv or version.