### PR TITLE
remove httptest in favour of wiremock, migrating all existing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,17 +385,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,16 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c3242926edf34aec4ac3a77108ad4854bffaa2e4ddc1824124ce59231302d5"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1319,28 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "httptest"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b44a11846bda8c9fe9194f9924db7132c34635c7ce020f180f6c5d46d2308f"
-dependencies = [
- "bstr",
- "bytes",
- "crossbeam-channel",
- "form_urlencoded",
- "futures",
- "http 0.2.11",
- "hyper 0.14.28",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,7 +1885,6 @@ dependencies = [
  "futures",
  "googletest",
  "hex",
- "httptest",
  "hyper 0.14.28",
  "jsonwebtoken",
  "log",
@@ -1943,6 +1899,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 
@@ -1966,7 +1923,6 @@ dependencies = [
  "futures",
  "git-version",
  "googletest",
- "httptest",
  "is-terminal",
  "jsonwebtoken",
  "keyring",
@@ -2183,15 +2139,9 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -2843,7 +2793,6 @@ dependencies = [
  "console",
  "googletest",
  "http 0.2.11",
- "httptest",
  "jsonwebtoken",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ url = { version = "2.5", features = ["serde"] }
 
 # dev & test dependencies
 http = "0.2.11"
-httptest = "0.15.5"
 mockall = "0.11.4"
 test-case = "3.3"
 uuid = { version = "1.7", features = ["v4"] }
@@ -91,7 +90,6 @@ simple-signal = "1.1"
 [dev-dependencies]
 assert-panic = "1.0"
 googletest.workspace = true
-httptest.workspace = true
 jsonwebtoken.workspace = true
 lib = { package = "pex_lib", path = "lib", version = "0.1.0", features = [
     "test_util",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -35,11 +35,11 @@ zeroize = { version = "1.8", features = ["zeroize_derive"] }
 [dev-dependencies]
 derive_more = "0.99.17"
 googletest.workspace = true
-httptest.workspace = true
 test-case.workspace = true
 test_helpers = { path = "../test_helpers" }
 uuid.workspace = true
 tokio = { workspace = true, features = ["full"] }
+wiremock.workspace = true
 
 [features]
 all_logs = []

--- a/src/end_to_end_tests/patch.rs
+++ b/src/end_to_end_tests/patch.rs
@@ -3,14 +3,12 @@
 use std::collections::HashMap;
 
 use googletest::prelude::*;
-use httptest::{
-    all_of,
-    matchers::{eq as heq, json_decoded, request},
-    responders::status_code,
-    Expectation, Server,
-};
 use serde_json::json;
 use test_helpers::get_test_context;
+use wiremock::{
+    matchers::{body_json, method, path},
+    Mock, MockServer,
+};
 
 use crate::{
     end_to_end_tests::configuration_helpers::{
@@ -23,18 +21,18 @@ use crate::{
 async fn patch_conference_config() {
     // Arrange
     let test_context = get_test_context();
-    let server = Server::run();
+    let server = MockServer::start().await;
 
-    configure_config_test_user(&test_context, server.url_str("").trim_end_matches('/'));
+    configure_config_test_user(&test_context, server.uri());
     configure_schemas_configuration_conference_only(&test_context);
 
-    server.expect(
-        Expectation::matching(all_of![
-            request::method_path("PATCH", "/api/admin/configuration/v1/conference/89/",),
-            request::body(json_decoded(heq(json!({"name": "patch_test_conf"})))),
-        ])
-        .respond_with(status_code(200)),
-    );
+    Mock::given(method("PATCH"))
+        .and(path("/api/admin/configuration/v1/conference/89/"))
+        .and(body_json(json!({"name": "patch_test_conf"})))
+        .respond_with(wiremock::ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
 
     // Act
     crate::run_with(

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -12,7 +12,6 @@ chrono.workspace = true
 console.workspace = true
 googletest.workspace = true
 http.workspace = true
-httptest.workspace = true
 jsonwebtoken.workspace = true
 log.workspace = true
 once_cell.workspace = true


### PR DESCRIPTION
As noted in #204, `wiremock` is a more flexible and intuitive alternative to `httptest` that suits our needs.