### PR TITLE
test_helpers: add `always_clean_up` configuration to prevent leaving behind test environment in `#[should_panic]` tests

### DIFF
--- a/lib/src/util/logging.rs
+++ b/lib/src/util/logging.rs
@@ -392,7 +392,7 @@ mod tests {
         logger.log(&record);
 
         // Assert
-        let log = std::fs::read_to_string(log_path).unwrap();
+        let log = std::fs::read_to_string(&log_path).unwrap();
         let log_lines: Vec<&str> = log.lines().collect();
 
         if should_log {
@@ -405,6 +405,7 @@ mod tests {
         } else {
             assert_that!(log_lines, empty());
         }
+        std::fs::remove_file(log_path).unwrap();
     }
 
     #[test]

--- a/src/end_to_end_tests/cache.rs
+++ b/src/end_to_end_tests/cache.rs
@@ -263,6 +263,6 @@ async fn schema_field_with_dict_type_does_not_cause_crash() {
     .unwrap();
 
     // Assert
-    let output = test_context.take_stdout();
+    let output = test_context.take_stderr();
     assert_that!(output, not(eq("")));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,11 @@ async fn main() -> ExitCode {
     let result = pexshell.run(args).await;
 
     if let Err(e) = result {
+        if let Some(code) = e.downcast_ref::<pexshell::ExitCode>() {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            return ExitCode::from(code.code() as u8);
+        }
+
         error!("fatal error occurred: {e:?}");
 
         let style = if is_stderr_interactive {

--- a/test_helpers/tests/logging.rs
+++ b/test_helpers/tests/logging.rs
@@ -14,26 +14,10 @@ fn test_expect_log() {
 }
 
 #[test]
-fn test_expect_log_verify_on_drop() {
-    let test_context = get_test_context();
-    let test_logger = test_context.logger();
-    test_logger.expect(all!(level(log::Level::Info), contains("Test info log")));
-    info!("Test info log");
-}
-
-#[test]
 #[should_panic]
 fn test_expect_log_fails() {
-    let test_context = get_test_context();
+    let test_context = get_test_context().always_clean_up();
     let test_logger = test_context.logger();
     test_logger.expect(all!(level(log::Level::Info), contains("Test info log")));
     test_logger.verify();
-}
-
-#[test]
-#[should_panic]
-fn test_expect_log_fails_verify_on_drop() {
-    let test_context = get_test_context();
-    let test_logger = test_context.logger();
-    test_logger.expect(all!(level(log::Level::Info), contains("Test info log")));
 }


### PR DESCRIPTION
Also fixes some other issues that lead to tests leaving behind files.

A notable change is that we no longer check test logger assertions automatically when dropping a test context, since panicking in the `drop` function has complications.