### PR TITLE
clippy fixes for rust 1.83

### DIFF
--- a/lib/src/mcu/auth/oauth2.rs
+++ b/lib/src/mcu/auth/oauth2.rs
@@ -42,7 +42,7 @@ struct Claims<'a> {
     token_id: &'a str,
 }
 
-impl<'a> serde::Serialize for Claims<'a> {
+impl serde::Serialize for Claims<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -140,7 +140,7 @@ impl<'callback> OAuth2<'callback> {
 }
 
 #[async_trait]
-impl<'callback> ApiClientAuth for OAuth2<'callback> {
+impl ApiClientAuth for OAuth2<'_> {
     async fn add_auth(
         &self,
         request: reqwest::RequestBuilder,

--- a/lib/src/mcu/mod.rs
+++ b/lib/src/mcu/mod.rs
@@ -126,7 +126,7 @@ pub struct ApiClient<'auth> {
     semaphore: Arc<Semaphore>,
 }
 
-impl<'auth> Clone for ApiClient<'auth> {
+impl Clone for ApiClient<'_> {
     fn clone(&self) -> Self {
         Self {
             http_client: self.http_client.clone(),
@@ -485,7 +485,7 @@ struct JsonError {
 
 #[allow(clippy::no_effect_underscore_binding)]
 #[async_trait]
-impl<'auth> IApiClient for ApiClient<'auth> {
+impl IApiClient for ApiClient<'_> {
     async fn send<'a>(&'a self, request: ApiRequest) -> anyhow::Result<ApiResponse<'a>> {
         let is_command = matches!(
             request,

--- a/lib/src/util/sensitive_string.rs
+++ b/lib/src/util/sensitive_string.rs
@@ -73,7 +73,7 @@ impl AsMut<Self> for SensitiveString {
 
 struct SecureStringVisitor;
 
-impl<'de> Visitor<'de> for SecureStringVisitor {
+impl Visitor<'_> for SecureStringVisitor {
     type Value = SensitiveString;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/lib/src/util/stream.rs
+++ b/lib/src/util/stream.rs
@@ -14,7 +14,7 @@ impl<'a, T> StreamWrapper<'a, T> {
     }
 }
 
-impl<'a, T> Stream for StreamWrapper<'a, T> {
+impl<T> Stream for StreamWrapper<'_, T> {
     type Item = T;
 
     fn poll_next(
@@ -25,7 +25,7 @@ impl<'a, T> Stream for StreamWrapper<'a, T> {
     }
 }
 
-impl<'a, T> std::iter::IntoIterator for StreamWrapper<'a, T> {
+impl<T> std::iter::IntoIterator for StreamWrapper<'_, T> {
     type IntoIter = BlockingStream<Self>;
     type Item = T;
 

--- a/test_helpers/src/future.rs
+++ b/test_helpers/src/future.rs
@@ -19,7 +19,7 @@ impl<'a, T> MockFuture<'a, T> {
     }
 }
 
-impl<'a, T: 'static> Future for MockFuture<'a, T> {
+impl<T: 'static> Future for MockFuture<'_, T> {
     type Output = T;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/test_helpers/src/logging/expect.rs
+++ b/test_helpers/src/logging/expect.rs
@@ -83,6 +83,7 @@ macro_rules! all {
 }
 
 /// Matches if and only if any of the given expectations completely match (`MatchResult::Complete`) on the given log message.
+///
 /// Expectations are tried in order. Partial matches (`MatchResult::Match`) are ignored.
 #[must_use]
 pub fn any(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
@@ -90,6 +91,7 @@ pub fn any(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
 }
 
 /// Matches if and only if any of the given expectations completely match (`MatchResult::Complete`) on the given log message.
+///
 /// Expectations are tried in order. Partial matches (`MatchResult::Match`) are ignored.
 #[macro_export]
 macro_rules! any {
@@ -101,8 +103,10 @@ macro_rules! any {
     }
 }
 
-/// Matches if all expectations completely match in the order they are given. Expectations do not all have to match
-/// completely on a single message, but the next expectation cannot begin matching until the previous expectation is complete.
+/// Matches if all expectations completely match in the order they are given.
+///
+/// Expectations do not all have to match completely on a single message, but the next expectation cannot begin matching
+/// until the previous expectation is complete.
 #[must_use]
 pub fn in_order(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     InOrder {
@@ -112,8 +116,10 @@ pub fn in_order(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     }
 }
 
-/// Matches if all expectations completely match in the order they are given. Expectations do not all have to match
-/// completely on a single message, but the next expectation cannot begin matching until the previous expectation is complete.
+/// Matches if all expectations completely match in the order they are given.
+///
+/// Expectations do not all have to match completely on a single message, but the next expectation cannot begin matching
+/// until the previous expectation is complete.
 /// Each log message can at most be matched against a single expectation, so two identical expectations in sequence
 /// would consume one matching log message (or matching sequence of messages) each.
 #[macro_export]
@@ -126,9 +132,10 @@ macro_rules! in_order {
     }
 }
 
-/// Matches if all expectations completely match. For each log, expectations are tried in the order they are given and
-/// when an expectation is matched, subsequent expectations are not tried. Expectations do not all have to match
-/// completely against any one log message.
+/// Matches if all expectations completely match.
+///
+/// For each log, expectations are tried in the order they are given and when an expectation is matched, subsequent
+/// expectations are not tried. Expectations do not all have to match completely against any one log message.
 #[must_use]
 pub fn set(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     Set {
@@ -138,9 +145,10 @@ pub fn set(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     }
 }
 
-/// Matches if all expectations completely match. For each log, expectations are tried in the order they are given and
-/// when an expectation is matched, subsequent expectations are not tried. Expectations do not all have to match
-/// completely against any one log message.
+/// Matches if all expectations completely match.
+///
+/// For each log, expectations are tried in the order they are given and when an expectation is matched, subsequent
+/// expectations are not tried. Expectations do not all have to match completely against any one log message.
 #[macro_export]
 macro_rules! set {
     [ $( $x:expr ),* $(,)? ] => {
@@ -151,9 +159,10 @@ macro_rules! set {
     }
 }
 
-/// Matches if any expectation completely matches. For each log, expectations are tried in the order they are given and
-/// when an expectation is matched, subsequent expectations are not tried. Expectations do not have to match
-/// completely against any one log message.
+/// Matches if any expectation completely matches.
+///
+/// For each log, expectations are tried in the order they are given and when an expectation is matched, subsequent
+/// expectations are not tried. Expectations do not have to match completely against any one log message.
 #[must_use]
 pub fn any_set(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     AnySet {
@@ -163,9 +172,10 @@ pub fn any_set(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {
     }
 }
 
-/// Matches if any expectation completely matches. For each log, expectations are tried in the order they are given and
-/// when an expectation is matched, subsequent expectations are not tried. Expectations do not have to match
-/// completely against any one log message.
+/// Matches if any expectation completely matches.
+///
+/// For each log, expectations are tried in the order they are given and when an expectation is matched, subsequent
+/// expectations are not tried. Expectations do not have to match completely against any one log message.
 #[macro_export]
 macro_rules! any_set {
     [ $( $x:expr ),* $(,)? ] => {
@@ -176,7 +186,9 @@ macro_rules! any_set {
     }
 }
 
-/// Matches if all expectations completely match. All expectations are tried on all log messages until all are complete.
+/// Matches if all expectations completely match.
+///
+/// All expectations are tried on all log messages until all are complete.
 /// Expectations do not have to match completely against any one log message.
 #[must_use]
 pub fn group(expectations: Vec<Box<dyn Expectation>>) -> impl Expectation {

--- a/test_helpers/src/logging/mod.rs
+++ b/test_helpers/src/logging/mod.rs
@@ -46,7 +46,7 @@ pub struct TestLoggerContext<'a> {
     _guard: RwLockWriteGuard<'a, ()>,
 }
 
-impl<'a> TestLoggerContext<'a> {
+impl TestLoggerContext<'_> {
     #[allow(dead_code)]
     pub fn get_config(&self) -> RwLockReadGuard<TestLoggerConfig> {
         self.test_logger.get_config()
@@ -81,7 +81,7 @@ impl<'a> TestLoggerContext<'a> {
     }
 }
 
-impl<'a> Drop for TestLoggerContext<'a> {
+impl Drop for TestLoggerContext<'_> {
     fn drop(&mut self) {
         self.clear();
     }


### PR DESCRIPTION
There are some new lints in Rust 1.83 that are breaking our CI. This PR fixes them.