### PR TITLE
run coverage on stable rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: ./.github/actions/prepare
         with:
           cache-id: debug-build
-          rust-version: nightly
-          rust-components: llvm-tools-preview
+          rust-version: stable
+          rust-components: llvm-tools
           cargo-install: cargo-nextest,cargo-llvm-cov
       - name: Run tests
         run: cargo llvm-cov --workspace --locked nextest --html --features ci


### PR DESCRIPTION
Nightly is no longer required to run coverage reports, so we should use stable rust instead.