### PR TITLE
ci: bump sccache-action 0.0.4 -> 0.0.9

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: mozilla-actions/sccache-action@v0.0.4
+    - uses: mozilla-actions/sccache-action@v0.0.8
     - id: toolchain
       uses: dtolnay/rust-toolchain@master
       with:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -20,7 +20,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: mozilla-actions/sccache-action@v0.0.8
+    - uses: mozilla-actions/sccache-action@v0.0.9
     - id: toolchain
       uses: dtolnay/rust-toolchain@master
       with:


### PR DESCRIPTION
Older versions are now deprecated as the API has changed.