### PR TITLE
clippy: fix new lint violations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,11 @@ test-case = "3.3"
 uuid = { version = "1.16", features = ["v4"] }
 wiremock = "0.6.3"
 
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+unnecessary_debug_formatting = "allow"
+
 
 [package]
 name = "pexshell"
@@ -112,3 +117,6 @@ all_logs = ["lib/all_logs"]
 ci = ["test_helpers/ci"]
 rustls-native-certs = ["reqwest/rustls-tls-native-roots"]
 rustls = ["reqwest/rustls-tls"]
+
+[lints]
+workspace = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -44,3 +44,6 @@ wiremock.workspace = true
 [features]
 all_logs = []
 test_util = ["dep:googletest"]
+
+[lints]
+workspace = true

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,6 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::nursery)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_const_for_fn)]
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -186,6 +186,7 @@ pub trait Provider: Send + Sync {
 /// Abstraction for accessing and modifying config.
 /// Does NOT take into account environment variables.
 pub trait Configurer: Send + Sync {
+    #[must_use]
     fn get_users(&self) -> &[User];
 
     /// Add a user to the users list.
@@ -625,7 +626,6 @@ impl Provider for Manager {
 }
 
 impl Configurer for Manager {
-    #[must_use]
     fn get_users(&self) -> &[User] {
         &self.config.users
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::nursery)]
-//#![warn(clippy::cargo)]
-#![allow(clippy::missing_errors_doc)]
-#![allow(clippy::missing_const_for_fn)]
-
 mod argparse;
 mod cli;
 mod config;
@@ -24,7 +17,7 @@ use lib::{
     mcu::{self, schema, Api},
     util::SimpleLogger,
 };
-use log::{error, warn, LevelFilter};
+use log::{error, LevelFilter};
 use parking_lot::RwLock;
 use serde_json::Value;
 #[cfg(unix)]
@@ -261,7 +254,7 @@ async fn main() -> ExitCode {
 }
 
 #[cfg(test)]
-#[expect(clippy::implicit_hasher)]
+#[expect(clippy::implicit_hasher, clippy::missing_errors_doc)]
 pub async fn run_with(
     args: &[String],
     env: HashMap<String, String>,

--- a/src/pexshell.rs
+++ b/src/pexshell.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::significant_drop_tightening)]
-
 use crate::{
     argparse,
     cli::{login, Console},

--- a/test_helpers/Cargo.toml
+++ b/test_helpers/Cargo.toml
@@ -34,3 +34,6 @@ test-case.workspace = true
 
 [features]
 ci = []
+
+[lints]
+workspace = true

--- a/test_helpers/src/fs/config.rs
+++ b/test_helpers/src/fs/config.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use chrono::{serde::ts_seconds_option, DateTime, Utc};
 use googletest::prelude::*;
 use p256::elliptic_curve::rand_core::OsRng;
+#[allow(clippy::wildcard_imports)]
 use p256::pkcs8::*;
 use p256::{ecdsa, pkcs8::LineEnding};
 use serde::Serialize;

--- a/test_helpers/src/lib.rs
+++ b/test_helpers/src/lib.rs
@@ -1,8 +1,3 @@
-#![deny(clippy::all)]
-#![warn(clippy::pedantic)]
-#![warn(clippy::nursery)]
-//#![warn(clippy::cargo)]
-#![allow(clippy::wildcard_imports)]
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_const_for_fn)]
 #![allow(clippy::redundant_pub_crate)]
@@ -136,6 +131,10 @@ impl Drop for TestContext {
         if !self.test_dir.exists() {
             return;
         }
+        #[expect(
+            clippy::unnecessary_debug_formatting,
+            reason = "debug formatting is intentional to clearly indicate the path in logs"
+        )]
         match self.clean_up {
             CleanUpMode::NotOnPanic if std::thread::panicking() => {
                 warn!(
@@ -317,6 +316,10 @@ impl TestContext {
     /// Gets the contents of the stdout buffer, simultaneously clearing it.
     pub fn take_stdout(&self) -> String {
         let mut stdout = String::new();
+        #[expect(
+            clippy::swap_with_temporary,
+            reason = "false positive - dropping the mutex guard does not drop the underlying value"
+        )]
         std::mem::swap(&mut stdout, &mut self.stdout_buffer.lock());
         stdout
     }
@@ -324,6 +327,10 @@ impl TestContext {
     /// Gets the contents of the stderr buffer, simultaneously clearing it.
     pub fn take_stderr(&self) -> String {
         let mut stderr = String::new();
+        #[expect(
+            clippy::swap_with_temporary,
+            reason = "false positive - dropping the mutex guard does not drop the underlying value"
+        )]
         std::mem::swap(&mut stderr, &mut self.stderr_buffer.lock());
         stderr
     }

--- a/test_helpers/tests/logging.rs
+++ b/test_helpers/tests/logging.rs
@@ -14,7 +14,7 @@ fn test_expect_log() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Some logging expectations were not met")]
 fn test_expect_log_fails() {
     let test_context = get_test_context().always_clean_up();
     let test_logger = test_context.logger();


### PR DESCRIPTION
Fixes new clippy lint violations in Rust 1.88.

Also switches over to using workspace lints to consolidate configuration.